### PR TITLE
:wrench: Add support to orbital decay lifetime analysis

### DIFF
--- a/ext/SatelliteAnalysisDecayExt/SatelliteAnalysisDecayExt.jl
+++ b/ext/SatelliteAnalysisDecayExt/SatelliteAnalysisDecayExt.jl
@@ -1,0 +1,33 @@
+module SatelliteAnalysisDecayExt
+
+using DifferentialEquations
+using LinearAlgebra
+using SatelliteAnalysis
+using StaticArrays
+
+############################################################################################
+#                                        Constants                                         #
+############################################################################################
+
+# Solar radiation pressure at 1 AU [N/m²].
+const _SOLAR_PRESSURE_1AU = 1367 / 299792457.999999984
+
+# Sun gravitational parameters [m³/s²].
+const _μ_SUN  = 1.32712440018e20
+
+# Moon gravitational parameters [m³/s²].
+const _μ_MOON = 4.9027988e12
+
+############################################################################################
+#                                         Includes                                         #
+############################################################################################
+
+include("accelerations.jl")
+include("dynamics.jl")
+include("gauss_matrices.jl")
+include("misc.jl")
+include("variational_rates.jl")
+include("main.jl")
+
+end
+

--- a/ext/SatelliteAnalysisDecayExt/accelerations.jl
+++ b/ext/SatelliteAnalysisDecayExt/accelerations.jl
@@ -1,0 +1,214 @@
+## Description #############################################################################
+#
+# Compute accelerations due to various perturbative forces acting on a satellite in orbit.
+#
+############################################################################################
+
+"""
+    _atmospheric_drag_acceleration(
+        jd_utc::Number,
+        r_ecef::AbstractVector{T},
+        v_ecef::AbstractVector{T},
+        area::Number,
+        mass::Number,
+        Cd::Number;
+        kwargs...
+    ) where T <: Number -> SVector{3, T}
+
+Compute the acceleration [m/s²] due to atmospheric drag in the ECEF frame using the
+NRLMSISE-00 model.
+
+# Arguments
+
+- `jd_utc::Number`: Julian date [UTC] in which the atmospheric drag will be computed.
+- `r_ecef::AbstractVector{T}`: Satellite position vector [m] in ECEF frame.
+- `v_ecef::AbstractVector{T}`: Satellite velocity vector [m/s] in ECEF frame.
+- `area::Number`: Effective cross-sectional area [m²] exposed to atmosphere.
+- `mass::Number`: Spacecraft mass [kg].
+- `Cd::Number`: Drag coefficient [-].
+
+# Keywords
+
+- `Cd::Number`: Drag coefficient [-].
+- `F107::Number`: Solar flux index.
+    (**Default** = `140`)
+- `Ap::Number`: Geomagnetic index.
+    (**Default** = `15`)
+
+!!! note
+
+    If `F107` or `Ap` are not provided, they will be automatically retrieved from the
+    `space_index` function using the provided `jd_utc`. In this case, the space indices
+    must be initialized.
+
+# Returns
+
+- `SVector{3, T}`: Drag acceleration vector [m/s²] represented in the ECEF frame.
+"""
+function _atmospheric_drag_acceleration(
+    jd_utc::Number,
+    r_ecef::AbstractVector{T},
+    v_ecef::AbstractVector{T},
+    area::Number,
+    mass::Number,
+    Cd::Number;
+    F107::Union{Nothing, Number} = 140,
+    Ap::Union{Nothing, Number}  = 15,
+) where T <: Number
+
+    lat, lon, h = ecef_to_geodetic(r_ecef)
+
+    # if (isnothing(F107) || isnothing(Ap))
+        F107 = space_index(Val(:F10obs_avg_center81), jd_utc)
+        Ap   = space_index(Val(:Ap_daily), jd_utc)
+    # end
+
+    atmos = AtmosphericModels.nrlmsise00(jd_utc, h, lat, lon, F107, F107, Ap)
+    ρ     = atmos.total_density
+
+    a_drag_ecef = -(1 // 2) * T(Cd) * (T(area) / T(mass)) * T(ρ) * norm(v_ecef) .* v_ecef
+
+    return a_drag_ecef
+end
+
+"""
+    _perturbational_gravity_acceleration(
+        gm::AbstractGravityModel,
+        jd_utc::Number,
+        r_ecef::AbstractVector;
+        kwargs...
+    ) -> SVector{3, Number}
+
+Compute the perturbational acceleration [m/s²] due to Earth's gravity field in the ECI
+frame. This algorithm obtains the acceleration from the gravity model `gm` at the ECEF
+position `r_ecef` [m] and the Julian date `jd_utc` [UTC]. This algorithm obtains the
+perturbed acceleration by computing the gravitational acceleration using `max_degree` and
+`max_order` and subtracting the central term (degree 0, order 0) to isolate the
+perturbational part.
+
+# Keywords
+
+- `max_degree::Int`: Maximum degree of the gravity model to consider.
+    (**Default**: 7).
+- `max_order::Int`: Maximum order of the gravity model to consider.
+    (**Default**: 0).
+
+# Returns
+
+- `SVector{3, Number}`: Perturbed acceleration vector [m/s²] represented in the ECEF frame.
+    The vector type is the same as the input gravity model.
+"""
+function _perturbational_gravity_acceleration(
+    gm::AbstractGravityModel,
+    jd_utc::Number,
+    r_ecef::AbstractVector;
+    max_degree::Int = 7,
+    max_order::Int = 0,
+)
+    # Total acceleration.
+    a_ecef_total = GravityModels.gravitational_acceleration(
+        gm,
+        r_ecef,
+        jd_utc;
+        max_degree = max_degree,
+        max_order = max_order
+    )
+
+    # Central term (degree 0, order 0).
+    a_ecef_central = GravityModels.gravitational_acceleration(
+        gm,
+        r_ecef,
+        jd_utc;
+        max_degree = 0,
+        max_order = 0
+    )
+
+    # Perturbational acceleration.
+    a_ecef_pert = a_ecef_total - a_ecef_central
+
+    return a_ecef_pert
+end
+
+"""
+    _point_mass_acceleration(
+        rsat_eci::AbstractVector{T},
+        rbody_eci::AbstractVector{T},
+        body_μ::Number
+    ) where T <: Number -> SVector{3, T}
+
+Compute the acceleration [m/s²] due to a third-body point mass (e.g. Sun, Moon, or another
+planet) on a satellite in the Earth-centered inertial (ECI) frame. `rsat_eci` is the
+satellite position vector [m] in ECI, `rbody_eci` is the point mass position vector [m] in
+ECI, and `body_μ` is the gravitational parameter of the point mass [m³/s²].
+
+# Returns
+
+- `SVector{3, T}`: Perturbational acceleration vector [m/s²].
+"""
+function _point_mass_acceleration(
+    rsat_eci::AbstractVector{T},
+    rbody_eci::AbstractVector{T},
+    body_μ::Number
+) where T <: Number
+
+    # Relative position vector of satellite w.r.t. point mass.
+    Δr_eci = rsat_eci .- rbody_eci
+
+    a_eci = -T(body_μ) * (Δr_eci / norm(Δr_eci)^3 + rbody_eci / norm(rbody_eci)^3)
+
+    return a_eci
+end
+
+"""
+    _solar_radiation_acceleration(
+        rsat_eci::AbstractVector{T},
+        rsun_eci::AbstractVector{T},
+        area::Number,
+        mass::Number,
+        C_r::Number
+    ) where T <: Number -> SVector{3, T}
+
+Compute the acceleration due to Solar Radiation Pressure **[1]**.
+
+The acceleration is computed as the effect of solar radiation pressure on the spacecraft,
+scaled by the inverse-square law with respect to the Sun–spacecraft distance. The worst-case
+assumption is used, where the effective area is always normal to the Sun direction.
+
+# Arguments
+
+- `sat_pos::AbstractVector{T}`: Spacecraft position vector [m] in an ECI frame.
+- `sun_pos::AbstractVector{T}`: Sun position vector [m] in an ECI frame.
+- `area::Number`: Effective cross-sectional area [m²] exposed to Sun.
+- `mass::Number`: Spacecraft mass [kg].
+- `C_r::Number`: Solar radiation pressure coefficient [-].
+
+# Returns
+
+- `SVector{3, T}`: Perturbational acceleration vector [m/s²].
+
+# Extended help
+
+## References
+
+- **[1]** Vallado, D. A. (2013). *Fundamentals of Astrodynamics and Applications*. 4th ed.
+    Microcosm Press, Hawthorne, CA.
+"""
+function _solar_radiation_acceleration(
+    rsat_eci::AbstractVector{T},
+    rsun_eci::AbstractVector{T},
+    area::Number,
+    mass::Number,
+    C_r::Number
+) where T <: Number
+
+    # Relative position vector of spacecraft w.r.t. Sun
+    Δr_eci = rsat_eci .- rsun_eci
+
+    # Acceleration due to solar radiation pressure
+    a_eci = C_r * T(area) / T(mass) *
+        _SOLAR_PRESSURE_1AU *
+        (ASTRONOMICAL_UNIT^2) *
+        (Δr_eci / norm(Δr_eci)^3)
+
+    return a_eci
+end

--- a/ext/SatelliteAnalysisDecayExt/dynamics.jl
+++ b/ext/SatelliteAnalysisDecayExt/dynamics.jl
@@ -1,0 +1,139 @@
+## Description #############################################################################
+#
+# Dynamics function to compute the satellite decay.
+#
+############################################################################################
+
+"""
+    _dynamics!(
+        du::AbstractVector{T},
+        state_mean::AbstractVector{T},
+        params::Dict,
+        t::Real
+    ) -> Nothing
+
+Compute Gauss mean-element derivatives with averaged perturbations.
+
+This routine computes the time derivatives of the mean orbital elements using Gauss'
+variational equations. It evaluates instantaneous forces on the mean-reference orbit for
+conservative perturbations (Earth gravity, third bodies) and adds temporally averaged rates
+for non-conservative perturbations (Atmospheric Drag and Solar Radiation Pressure).
+
+!!! note
+
+    - Conservative perturbations are evaluated on the mean orbit at evenly spaced mean anomalies.
+    - Non-conservative perturbations are added via averaged routines (drag and SRP).
+    - Units must be consistent: meters, seconds, kilograms.
+
+# Keywords
+
+- `du::AbstractVector{T}`: Output derivative vector `[da, de, di, dΩ, dω, dM]`.
+- `state_mean::AbstractVector{T}`: Mean orbital elements `[a, e, i, Ω, ω, M]`.
+- `params::Dict`: Dictionary with environment/model parameters (e.g., `jd0_utc`, `F107`, `Ap`).
+- `t::Real`: Time since epoch [s].
+
+# References
+
+- **[1]** Battin, R. H. (1999). An Introduction to the Mathematics and Methods of
+    Astrodynamics. Revised ed. AIAA Education Series, Reston, VA.
+"""
+function _dynamics!(
+    du::AbstractVector{T},
+    u::AbstractVector{T},
+    params,
+    t::Real
+) where T <: Number
+    # Gravity model.
+    gm = params.gm
+    μ  = GravityModels.gravity_constant(gm)
+
+    # Time and ephemerides.
+    jd₀_utc = params.jd₀_utc
+    jd_utc  = jd₀_utc + t / 86400.0
+
+    # Unpack mean orbital elements.
+    ā, ē, ī, Ω̄, ω̄, M̄ = _equinoctial_to_classical(u)
+    ē = max(ē, 1e-6)
+    ī = max(ī, 1e-6)
+
+    # Auxiliaries with mean elements.
+    ē² = ē^2
+    η² = 1 - ē²
+    p̄  = ā * η²
+    h̄  = √(μ * p̄)
+    n̄  = √(μ / ā^3)
+    η̄  = √η²
+
+    # Third-body constants and positions.
+    rsun_mod  = sun_position_mod(jd_utc)
+    rmoon_mod = moon_position_mod(jd_utc, Val(:Vallado))
+
+    # Convert the vectors to TOD.
+    D_tod_mod = r_eci_to_eci(MOD(), jd_utc, TOD(), jd_utc)
+    rsun_tod  = D_tod_mod * rsun_mod
+    rmoon_tod = D_tod_mod * rmoon_mod
+
+    # Convert the vectors to PEF.
+    D_pef_tod = r_eci_to_ecef(TOD(), PEF(), jd_utc)
+    D_tod_pef = r_ecef_to_eci(PEF(), TOD(), jd_utc)
+
+    # Initialization of averaged variation rates.
+    ∂C_avg = @SVector zeros(T, 6)
+
+    N = params.num_sampling_points_per_orbit
+
+    # NOTE: Theoretically, we need to update the Moon and Sun positions at each sampling
+    # point, but for efficiency, we assume they are constant over one orbit.
+    for k in 0:(N - 1)
+        # Sampling point along the mean orbit.
+        M̄k = mod(M̄ + (2π * k / N), 2π)
+        f̄k = mean_to_true_anomaly(ē, M̄k)
+
+        # Position and velocity from mean orbital elements.
+        rk_tod, vk_tod = _coe_to_rv(ā, ē, ī, Ω̄, ω̄, M̄k)
+        rk = norm(rk_tod)
+
+        rk_pef = D_pef_tod * rk_tod
+
+        # Conservative perturbations in TOD.
+        δak_tod =
+            (D_tod_pef * _perturbational_gravity_acceleration(gm, jd_utc, rk_pef)) +
+            _point_mass_acceleration(rk_tod, rsun_tod, _μ_SUN) +
+            _point_mass_acceleration(rk_tod, rmoon_tod, _μ_MOON)
+
+        # Perturbations acceleration in Hill frame
+        Dk_hill_tod = _r_eci_to_hill(rk_tod, vk_tod)
+        δak_hill    = Dk_hill_tod * δak_tod
+
+        # Instantaneous Gauss equations (with mean parameters)
+        Ak, Bk = _gauss_variational_matrices(ā, ē, ī, ω̄, f̄k, rk, p̄, h̄, η̄, n̄)
+
+        # Accumulation
+        ∂C_avg = ∂C_avg + (Ak * δak_hill + Bk)
+    end
+
+    # Average of conservative perturbations.
+    ∂C_total = ∂C_avg / N
+
+    ∂u_J₂² = J₂²_variational_rates(ā, ē, ī, ω̄, gm)
+
+    # Non-conservative perturbations (averaged)
+    ∂u_drag, ∂u_srp = _atmospheric_drag_and_solar_radiation_pressure_variational_rates(
+        jd_utc,
+        ā,
+        ē,
+        ī,
+        Ω̄,
+        ω̄,
+        rsun_tod,
+        params
+    )
+
+    ∂C_total = ∂C_total + ∂u_drag + ∂u_srp + ∂u_J₂²
+
+    Jec = _coe_to_rv_jacobian(ē, ī, Ω̄, ω̄)
+
+    du[1:6] .= Jec * ∂C_total
+
+    return nothing
+end

--- a/ext/SatelliteAnalysisDecayExt/gauss_matrices.jl
+++ b/ext/SatelliteAnalysisDecayExt/gauss_matrices.jl
@@ -1,0 +1,94 @@
+## Description #############################################################################
+#
+# Functions to compute the Gauss variational matrices A(y) and B for orbital element
+# propagation under perturbations.
+#
+############################################################################################
+
+"""
+    _gauss_variational_matrices(
+        a::T,
+        e::T,
+        i::T,
+        ω::T,
+        f::T,
+        r::T,
+        p::T,
+        h::T,
+        η::T,
+        n::T
+    ) where T <: Number -> Tuple{SMatrix{6, 3, T}, SVector{6, T}}
+
+Compute Gauss variational matrices A(y) and B **[1]**.
+
+This routine builds the matrix form of Gauss' variational equations:
+
+    ẏ = A(y) * p + B
+
+where `y = [a, e, i, Ω, ω, M]`, `p = [u_r, u_θ, u_h]`.
+
+# Keywords
+
+- `a::Number`: Semi-major axis [m].
+- `e::Number`: Stabilized eccentricity (≥ 1e-6) [-].
+- `i::Number`: Inclination [rad].
+- `ω::Number`: Argument of perigee [rad].
+- `f::Number`: True anomaly [rad].
+- `r::Number`: Radius [m].
+- `p::Number`: Semi-latus rectum [m].
+- `h::Number`: Specific angular momentum [m²/s].
+- `η::Number`: √(1 - e²) [-].
+- `n::Number`: Mean motion [rad/s].
+
+# Returns
+
+- `A::Matrix{Float64}`: 6x3 matrix multiplying perturbation vector `[u_r, u_θ, u_h]`.
+- `B::Vector{Float64}`: Constant vector `[0, 0, 0, 0, 0, n]`.
+
+# Extended help
+
+# References
+
+- **[1]** Battin, R. H. (1999). An Introduction to the Mathematics and Methods of
+    Astrodynamics. Revised ed. AIAA Education Series, Reston, VA.
+"""
+function _gauss_variational_matrices(
+    a::T,
+    e::T,
+    i::T,
+    ω::T,
+    f::T,
+    r::T,
+    p::T,
+    h::T,
+    η::T,
+    n::T
+) where T <: Number
+    sin_f, cos_f = sincos(f)
+    sin_i, cos_i = sincos(i)
+
+    θ  = f + ω
+    sin_θ, cos_θ = sincos(θ)
+
+    a²      = a^2
+    h_sin_i = h * sin_i
+    r_sin_θ = r * sin_θ
+    k₁      = 2a² / h
+    he      = h * e
+    re      = r * e
+    η_o_he  = η / he
+    psr     = p + r
+
+    A = @SMatrix T[
+        (k₁ * e * sin_f)              (k₁ * p / r)              0
+        (p / h * sin_f)               ((psr * cos_f + re) / h)  0
+        0                             0                         (r * cos_θ / h)
+        0                             0                         (r_sin_θ / h_sin_i)
+        (-p / he * cos_f)             (psr / he * sin_f)      (-r_sin_θ * cos_i / h_sin_i)
+        (η_o_he * (p * cos_f - 2re))  (-η_o_he * psr * sin_f)   0
+    ]
+
+    B = T[0, 0, 0, 0, 0, n]
+
+    return A, B
+end

--- a/ext/SatelliteAnalysisDecayExt/main.jl
+++ b/ext/SatelliteAnalysisDecayExt/main.jl
@@ -1,0 +1,79 @@
+## Description #############################################################################
+#
+# Main function to compute the decay analysis of a satellite in orbit.
+#
+############################################################################################
+
+function SatelliteAnalysis.decay_analysis(
+    orb::KeplerianElements;
+    # Required keywords.
+    satellite_mass::Number,
+    satellite_mean_area::Number,
+    # Optional keywords.
+    gravity_model::Union{AbstractGravityModel, Nothing} = nothing,
+    num_sampling_points_per_orbit::Int = 33,
+    Ap::Number = 15.0,
+    C_d::Number = 2.2,
+    C_r::Number = 1.25,
+    F107::Number = 140.0,
+    tf::Number = 30 * 365.25 * 86400.0,
+)
+    M = true_to_mean_anomaly(orb.e, orb.f)
+    ā, ē, ī, Ω̄, ω̄, M̄ = _osculating_to_mean_elements(orb.a, orb.e, orb.i, orb.Ω, orb.ω, M)
+    u = Vector(_classical_to_equinoctial(ā, ē, ī, Ω̄, ω̄, M̄))
+    # u = Vector(_classical_to_equinoctial(orb.a, orb.e, orb.i, orb.Ω, orb.ω, M))
+
+    tspan = (0.0, tf)
+
+    gm = isnothing(gravity_model) ?
+        GravityModels.load(IcgemFile, fetch_icgem_file(:EGM2008)) :
+        gravity_model
+
+    params = (
+        satellite_mean_area           = satellite_mean_area,
+        satellite_mass                = satellite_mass,
+        num_sampling_points_per_orbit = num_sampling_points_per_orbit,
+        Ap                            = Ap,
+        C_d                           = C_d,
+        C_r                           = C_r,
+        F107                          = F107,
+        gm                            = gm,
+        jd₀_utc                       = orb.t,
+    )
+
+    cbset = CallbackSet(ContinuousCallback(_cb_altitude_condition, _cb_altitude_affect!))
+
+    prob = ODEProblem(_dynamics!, u, tspan, params)
+    sol = solve(
+        prob,
+        Tsit5();
+        dt       = 24.0 * 60 * 60,
+        reltol   = 1e-8,
+        abstol   = 1e-8,
+        callback = cbset,
+        maxiters = 1e8
+    )
+
+    return sol
+end
+
+############################################################################################
+#                                    Private Functions                                     #
+############################################################################################
+
+function _cb_altitude_condition(u, t, integrator)
+    a_mean, e_mean, i_mean, Ω_mean, ω_mean, M_mean = _equinoctial_to_classical(u)
+
+    a_osc, e_osc, i_osc, Ω_osc, ω_osc, M_osc =
+        _mean_to_osculating_elements(a_mean, e_mean, i_mean, Ω_mean, ω_mean, M_mean)
+
+    r_tod, _ = _coe_to_rv(a_osc, e_osc, i_osc, Ω_osc, ω_osc, M_osc)
+    altitude = norm(r_tod) - EARTH_EQUATORIAL_RADIUS
+
+    return altitude - 120e3
+end
+
+function _cb_altitude_affect!(integrator)
+    terminate!(integrator)
+    return nothing
+end

--- a/ext/SatelliteAnalysisDecayExt/misc.jl
+++ b/ext/SatelliteAnalysisDecayExt/misc.jl
@@ -1,0 +1,424 @@
+## Description #############################################################################
+#
+# Miscellaneous functions for the SatelliteAnalysisDecayExt package.
+#
+############################################################################################
+
+"""
+    _classical_to_equinoctial(
+        a::T,
+        e::T,
+        i::T,
+        Ω::T,
+        ω::T,
+        M::T
+    ) where T<:Number -> SVector{6, T}
+
+Compute the equinoctial orbital elements from the classical orbital elements **[1]**:
+
+- `a::T`: Semi-major axis [m].
+- `e::T`: Eccentricity (0 ≤ e < 1) [-].
+- `i::T`: Inclination [rad].
+- `Ω::T`: Right Ascension of Ascending Node [rad].
+- `ω::T`: Argument of Perigee [rad].
+- `M::T`: Mean Anomaly [rad].
+
+# Returns
+
+- `SVector{6, T}`: Equinoctial orbital elements `[a, ψ, e_x, e_y, i_x, i_y]`.
+
+# Extended help
+
+## References
+
+- **[1]** Battin, R. H. (1999). An Introduction to the Mathematics and Methods of
+    Astrodynamics. Revised ed. AIAA Education Series, Reston, VA.
+"""
+function _classical_to_equinoctial(a::T, e::T, i::T, Ω::T, ω::T, M::T) where T<:Number
+    ψ = M + Ω + ω
+    ξ = Ω + ω
+
+    sin_ξ, cos_ξ = sincos(ξ)
+    sin_Ω, cos_Ω = sincos(Ω)
+    sin_io2      = sin(i / 2)
+
+    e_x = e * cos_ξ
+    e_y = e * sin_ξ
+    i_x = sin_io2 * cos_Ω
+    i_y = sin_io2 * sin_Ω
+
+    return @SVector [a, ψ, e_x, e_y, i_x, i_y]
+end
+
+"""
+    _coe_to_rv(
+        a::T,
+        e::T,
+        i::T,
+        Ω::T,
+        ω::T,
+        M::T
+    ) where T <: Number -> SVector{3, T}, SVector{3, T}
+
+Compute position and velocity vectors from Classical Orbital Elements:
+
+- `a::T`: Semi-major axis [m].
+- `e::T`: Eccentricity (0 ≤ e < 1) [-].
+- `i::T`: Inclination [rad].
+- `Ω::T`: Right Ascension of Ascending Node [rad].
+- `ω::T`: Argument of Perigee [rad].
+- `M::T`: Mean Anomaly [rad].
+
+# Returns
+
+- `SVector{3, T}`: Position vector in ECI frame [m].
+- `SVector{3, T}`: Velocity vector in ECI frame [m/s].
+"""
+function _coe_to_rv(a::T, e::T, i::T, Ω::T, ω::T, M::T) where T <: Number
+    f  = mean_to_true_anomaly(e, M)
+    ke = KeplerianElements(0.0, a, e, i, Ω, ω, f)
+
+    return kepler_to_rv(ke)
+end
+
+"""
+    _coe_to_rv_jacobian(e::T, i::T, Ω::T, ω::T) where T <: Number -> SMatrix{6, 6, T}
+
+Compute the Jacobian matrix of the transformation from Classical Orbital Elements (COE) to
+Equinoctial Elements.
+
+This routine computes the Jacobian matrix associated with the mapping between classical
+orbital elements and equinoctial elements. The Jacobian provides the partial derivatives of
+equinoctial elements with respect to classical orbital elements, which is useful for
+sensitivity analysis, covariance propagation, and orbit determination.
+
+# Arguments
+
+- `e::Number`: Eccentricity (0 ≤ e < 1) [-].
+- `i::Number`: Inclination [rad].
+- `Ω::Number`: Right ascension of ascending node [rad].
+- `ω::Number`: Argument of perigee [rad].
+
+# Returns
+
+- `SMatrix{T, 6, 6}`: Jacobian matrix `J` of size `6x6`, where each entry corresponds to the
+    partial derivative of an equinoctial element with respect to a classical orbital
+    element.
+"""
+function _coe_to_rv_jacobian(e::T, i::T, Ω::T, ω::T) where T <: Number
+    ξ = Ω + ω
+
+    sin_ξ, cos_ξ = sincos(ξ)
+    sin_Ω, cos_Ω = sincos(Ω)
+    cos_io2      = cos(i / 2)
+    sin_io2      = sin(i / 2)
+
+    # E1 (a) -> [1, 1]
+    J₁₁ = T(1)
+
+    # E2 (Ψ = M + Ω + ω) -> [2, 4], [2, 5], [2, 6]
+    J₂₄ = T(1)                          # dΨ/dΩ
+    J₂₅ = T(1)                          # dΨ/dω
+    J₂₆ = T(1)                          # dΨ/dM
+
+    # E3 (e_x = e cos(ξ)) -> [3, 2], [3, 4], [3, 5]
+    J₃₂ = cos_ξ                         # de_x/de
+    J₃₄ = -e * sin_ξ                    # de_x/dΩ
+    J₃₅ = -e * sin_ξ                    # de_x/dω
+
+    # E4 (e_y = e sin(ξ)) -> ₄₂, [4, 4], [4, 5]
+    J₄₂ = sin_ξ                         # de_y/de
+    J₄₄ = e * cos_ξ                     # de_y/dΩ
+    J₄₅ = e * cos_ξ                     # de_y/dω
+
+    # E5 (i_x = sin(i/2) cos(Ω)) -> [5, 3], [5, 4]
+    J₅₃ = (1 // 2) * cos_io2 * cos_Ω    # dq/di
+    J₅₄ = -sin_io2 * sin_Ω              # dq/dΩ
+
+    # E6 (i_y = sin(i/2) sin(Ω)) -> [6, 3], [6, 4]
+    J₆₃ = (1 // 2) * cos_io2 * sin_Ω    # dp/di
+    J₆₄ = sin_io2 * cos_Ω               # dp/dΩ
+
+    J = @SMatrix T[
+        J₁₁   0    0    0   0   0
+         0    0    0   J₂₄ J₂₅ J₂₆
+         0   J₃₂   0   J₃₄ J₃₅  0
+         0   J₄₂   0   J₄₄ J₄₅  0
+         0    0   J₅₃  J₅₄  0   0
+         0    0   J₆₃  J₆₄  0   0
+    ]
+
+    return J
+end
+
+"""
+    _equinoctial_to_classical(
+        eq::AbstractVector{T}
+    ) where T <: Number -> NTuple{6, T}
+
+Conversion from Equinoctial Elements `equino` to Classical Orbital Elements (COE) **[1]**.
+The input `equino` is a vector of equinoctial orbital elements `[a, ψ, e_x, e_y, i_x, i_y]`,
+where:
+
+- `a`    [m]   Semi-major axis
+- `ψ`    [rad] Mean longitude
+- `e_x`  [-]   Eccentricity vector component along cos(Ω+ω)
+- `e_y`  [-]   Eccentricity vector component along sin(Ω+ω)
+- `i_x`  [-]   Inclination half-angle component along cos(Ω)
+- `i_y`  [-]   Inclination half-angle component along sin(Ω)
+
+This routine ensures proper normalization of angles and handles potential singularities in
+eccentricity and inclination.
+
+!!! note
+
+    - Eccentricity `e` is constrained to `e ≥ 1e-6` to avoid division by zero.
+    - Inclination is reconstructed from half-angle parameters `(i_x, i_y)`.
+    - All angular quantities are normalized to the range `[0, 2π)` [rad].
+
+# Returns
+
+- `T`: Semi-major axis [m].
+- `T`: Eccentricity [-].
+- `T`: Inclination [rad].
+- `T`: Right ascension of ascending node [rad].
+- `T`: Argument of perigee [rad].
+- `T`: Mean anomaly [rad].
+
+# Extended help
+
+## References
+
+- **[1]** Battin, R. H. (1999). An Introduction to the Mathematics and Methods of
+    Astrodynamics. Revised ed. AIAA Education Series, Reston, VA.
+"""
+function _equinoctial_to_classical(
+    eq::AbstractVector{T}
+) where T <: Number
+    # Unpack.
+    a, ψ, e_x, e_y, i_x, i_y = eq
+
+    e = max(√(e_x^2 + e_y^2), T(1e-6))
+
+    i_half_sq = clamp(i_x^2 + i_y^2, 0, 1)
+    i = 2asin(√i_half_sq)
+
+    Ω = atan(i_y, i_x)
+    ξ = atan(e_y, e_x)
+
+    Ω = mod(Ω, 2π)
+    ξ = mod(ξ, 2π)
+    ω = mod(ξ - Ω, 2π)
+    M = mod(ψ - ξ, 2π)
+
+    a, e, i, Ω, ω, M = _normalize_classical_elements(a, e, i, Ω, ω, M)
+
+    return a, e, i, Ω, ω, M
+end
+
+"""
+    _mean_to_osculating_elements(
+        a::T,
+        e::T,
+        i::T,
+        Ω::T,
+        ω::T,
+        M::T
+    ) where T <: Number -> NTuple{6, T}
+
+Convert the mean classical elements `[a, e, i, Ω, ω, M]` to osculating elements under the J2
+perturbation model **[1]**.
+
+# Arguments
+
+- `a::T`: Semi-major axis [m].
+- `e::T`: Eccentricity (0 ≤ e < 1) [-].
+- `i::T`: Inclination [rad].
+- `Ω::T`: Right ascension of ascending node [rad].
+- `ω::T`: Argument of perigee [rad].
+- `M::T`: Mean anomaly [rad].
+
+# Returns
+
+- `T`: Osculating semi-major axis [m].
+- `T`: Osculating eccentricity [-].
+- `T`: Osculating inclination [rad].
+- `T`: Osculating right ascension of ascending node [rad].
+- `T`: Osculating argument of perigee [rad].
+- `T`: Osculating mean anomaly [rad].
+
+# Extended help
+
+# References
+
+- **[1]** Vallado, D. A. (2013). *Fundamentals of Astrodynamics and Applications*. 4th ed.
+    Microcosm Press, Hawthorne, CA.
+"""
+function _mean_to_osculating_elements(a::T, e::T, i::T, Ω::T, ω::T, M::T) where T <: Number
+    # Normalize.
+    a, e, i, Ω, ω, M = _normalize_classical_elements(a, e, i, Ω, ω, M)
+    e = max(e, 1e-6)
+    i = max(i, 1e-6)
+
+    # Convert to osculating.
+    orb_tod      = KeplerianElements(0.0, a, e, i, Ω, ω, mean_to_true_anomaly(e, M))
+    orbp         = Propagators.init(Val(:J2osc), orb_tod)
+    r_tod, v_tod = Propagators.propagate!(orbp, 0.0)
+    ke           = rv_to_kepler(r_tod, v_tod)
+
+    ap = ke.a
+    ep = ke.e
+    ip = ke.i
+    Ωp = ke.Ω
+    ωp = ke.ω
+    Mp = true_to_mean_anomaly(ke.e, ke.f)
+
+    # Return new state.
+    return ap, ep, ip, Ωp, ωp, Mp
+end
+
+"""
+    _osculating_to_mean_elements(
+        a::T,
+        e::T,
+        i::T,
+        Ω::T,
+        ω::T,
+        M::T
+    ) where T <: Number -> NTuple{6, T}
+
+Convert the osculating classical elements `[a, e, i, Ω, ω, M]` to mean elements under the J2
+perturbation model **[1]**.
+
+# Arguments
+
+- `a::T`: Semi-major axis [m].
+- `e::T`: Eccentricity (0 ≤ e < 1) [-].
+- `i::T`: Inclination [rad].
+- `Ω::T`: Right ascension of ascending node [rad].
+- `ω::T`: Argument of perigee [rad].
+- `M::T`: Mean anomaly [rad].
+
+# Returns
+
+- `T`: Mean semi-major axis [m].
+- `T`: Mean eccentricity [-].
+- `T`: Mean inclination [rad].
+- `T`: Mean right ascension of ascending node [rad].
+- `T`: Mean argument of perigee [rad].
+- `T`: Mean mean anomaly [rad].
+
+# Extended help
+
+# References
+
+- **[1]** Vallado, D. A. (2013). *Fundamentals of Astrodynamics and Applications*. 4th ed.
+    Microcosm Press, Hawthorne, CA.
+"""
+function _osculating_to_mean_elements(a::T, e::T, i::T, Ω::T, ω::T, M::T) where T <: Number
+    # Normalize.
+    a, e, i, Ω, ω, M = _normalize_classical_elements(a, e, i, Ω, ω, M)
+    e = max(e, 1e-6)
+    i = max(i, 1e-6)
+
+    # Convert to mean.
+    orb_osc_tod  = KeplerianElements(0.0, a, e, i, Ω, ω, mean_to_true_anomaly(e, M))
+    r_tod, v_tod = kepler_to_rv(orb_osc_tod)
+    ke, _        = fit_j2osc_mean_elements([0], [r_tod], [v_tod]; max_iterations = 50, verbose = false)
+
+    ap = ke.a
+    ep = ke.e
+    ip = ke.i
+    Ωp = ke.Ω
+    ωp = ke.ω
+    Mp = true_to_mean_anomaly(ke.e, ke.f)
+
+    # Return new state.
+    return ap, ep, ip, Ωp, ωp, Mp
+end
+
+"""
+    _normalize_classical_elements(
+        a::T,
+        e::T,
+        i::T,
+        Ω::T,
+        ω::T,
+        M::T
+    ) where T <: Number -> NTuple{6, T}
+
+Normalize classical orbital elements to valid ranges:
+
+- Semi-major axis `a` is forced positive.
+- Eccentricity `e` is clamped to non-negative values.
+- Inclination `i` is clamped to [0, π] [rad].
+- Angular elements (Ω, ω, M) are normalized to [0, 2π) [rad].
+
+# Arguments
+
+- `a::T`: Semi-major axis [m].
+- `e::T`: Eccentricity [-].
+- `i::T`: Inclination [rad].
+- `Ω::T`: Right Ascension of Ascending Node [rad].
+- `ω::T`: Argument of Perigee [rad].
+- `M::T`: Mean Anomaly [rad].
+
+# Returns
+
+- `T`: Normalized semi-major axis [m].
+- `T`: Normalized eccentricity [-].
+- `T`: Normalized inclination [rad].
+- `T`: Normalized right ascension of ascending node [rad].
+- `T`: Normalized argument of perigee [rad].
+- `T`: Normalized mean anomaly [rad].
+"""
+function _normalize_classical_elements(
+    a::T,
+    e::T,
+    i::T,
+    Ω::T,
+    ω::T,
+    M::T
+) where T <: Number
+    a_norm = a > 0 ? a : abs(a)
+    e_norm = e < 0 ? 0.0 : e
+    i_norm = clamp(i, 0.0, π)
+    Ω_norm = mod(Ω, 2π)
+    ω_norm = mod(ω, 2π)
+    M_norm = mod(M, 2π)
+
+    return a_norm, e_norm, i_norm, Ω_norm, ω_norm, M_norm
+end
+
+"""
+    _r_eci_to_hill(
+        r_eci::AbstractVector{T},
+        v_eci::AbstractVector{T}
+    ) where T <: Number -> SMatrix{3, 3, T}
+
+Compute the Direction Cosine Matrix (DCM) from an Earth Centered Inertial (ECI) frame to the
+Hill frame (also known as then RTN or RSW frame), given the satellite position [m] and
+satellite velocity [m/s] in the eci reference frame.
+
+The Hill frame is defined as follows:
+
+- X-axis: along the radial direction (from Earth to satellite).
+- Y-axis: along the along-track direction (in the direction of motion).
+- Z-axis: along the cross-track direction (perpendicular to the orbital plane).
+"""
+function _r_eci_to_hill(
+    r_eci::AbstractVector{T},
+    v_eci::AbstractVector{T}
+) where T <: Number
+    r̄_eci = normalize(r_eci)
+    h_eci = cross(r_eci, v_eci)
+    h̄_eci = normalize(h_eci)
+    θ̄_eci = cross(h̄_eci, r̄_eci)
+
+    return @SMatrix [
+        r̄_eci[1] r̄_eci[2] r̄_eci[3]
+        θ̄_eci[1] θ̄_eci[2] θ̄_eci[3]
+        h̄_eci[1] h̄_eci[2] h̄_eci[3]
+    ]
+end
+

--- a/ext/SatelliteAnalysisDecayExt/variational_rates.jl
+++ b/ext/SatelliteAnalysisDecayExt/variational_rates.jl
@@ -1,0 +1,259 @@
+## Description #############################################################################
+#
+# Compute variational rates due to non-conservative perturbations.
+#
+############################################################################################
+
+"""
+    _atmospheric_drag_and_solar_radiation_pressure_variational_rates(
+        jd_utc::T,
+        ā::T,
+        ē::T,
+        ī::T,
+        Ω̄::T,
+        ω̄::T,
+        rsun_tod::SVector{3, T},
+        params::NamedTuple
+    ) where T<:Number -> SVector{6, T}, SVector{6, T}
+
+Compute averaged Gauss variation rates due to atmospheric drag and solar radiation pressure
+**[1]**. This routine calculates the averaged rates of change of the orbital elements under
+atmospheric drag using quadrature equally spaced in true anomaly and temporal weighting
+(`r²/h`).
+
+# Arguments
+
+- `jd_utc::T`: Julian date [UTC] at which the rates are computed.
+- `ā::T`: Mean semi-major axis [m].
+- `ē::T`: Mean eccentricity [-].
+- `ī::T`: Mean inclination [rad].
+- `Ω̄::T`: Mean right ascension of ascending node [rad].
+- `ω̄::T`: Mean argument of perigee [rad].
+- `rsun_tod::SVector{3, T}`: Sun position vector [m] in TOD frame.
+- `params::NamedTuple`: Named tuple containing environment parameters:
+    - `gm::AbstractGravityModel`: Gravity model for Earth.
+    - `num_sampling_points_per_orbit::Int`: Number of quadrature points for averaging.
+    - `satellite_mass::Number`: Spacecraft mass [kg].
+    - `satellite_mean_area::Number`: Effective cross-sectional area [m²].
+    - `Ap::Number`: Geomagnetic index.
+    - `C_d::Number`: Drag coefficient [-].
+    - `C_r::Number`: Reflectivity coefficient [-].
+    - `F107::Number`: Solar flux index.
+
+# Returns
+
+- `SVector{6, T}`: Averaged Gauss rates due to atmospheric drag.
+- `SVector{6, T}`: Averaged Gauss rates due to solar radiation pressure.
+
+# References
+
+- **[1]** Battin, R. H. (1999). An Introduction to the Mathematics and Methods of
+    Astrodynamics. Revised ed. AIAA Education Series, Reston, VA.
+"""
+function _atmospheric_drag_and_solar_radiation_pressure_variational_rates(
+    jd_utc::T,
+    ā::T,
+    ē::T,
+    ī::T,
+    Ω̄::T,
+    ω̄::T,
+    rsun_tod::SVector{3, T},
+    params::NamedTuple
+) where T<:Number
+    Ap        = params.Ap
+    C_d       = params.C_d
+    C_r       = params.C_r
+    F107      = params.F107
+    N         = params.num_sampling_points_per_orbit
+    gm        = params.gm
+    mass      = params.satellite_mass
+    mean_area = params.satellite_mean_area
+
+    μ = GravityModels.gravity_constant(gm)
+
+    # Auxiliaries with mean elements.
+    ē  = max(ē, 1e-6)
+    ī  = max(ī, 1e-6)
+    ē² = ē^2
+    η̄² = 1 - ē²
+    p̄  = ā * η̄²
+    h̄  = √(μ * p̄)
+    n̄  = √(μ / ā^3)
+    η̄  = √η̄²
+
+    D_tod_pef = r_ecef_to_eci(PEF(), TOD(), jd_utc)
+
+    # Initialization.
+    ∂u_drag = @SVector zeros(T, 6)
+    ∂u_srp  = @SVector zeros(T, 6)
+    Wsum    = zero(T)
+
+    # Quadrature in f ∈ [0, 2π) [rad].
+    for k in 0:(N - 1)
+        f̄k = 2π * k / N
+        M̄k = mod(true_to_mean_anomaly(ē, f̄k), 2π)
+
+        # Obtain osculating elements.
+        a, e, i, Ω, ω, M = _mean_to_osculating_elements(ā, ē, ī, Ω̄, ω̄, M̄k)
+
+        # Position and velocity in TOD.
+        rk_tod, vk_tod = _coe_to_rv(a, e, i, Ω, ω, M)
+        rk² = dot(rk_tod, rk_tod)
+        rk  = √rk²
+
+        # Matrix to convert TOD to Hill frame.
+        D_hill_tod = _r_eci_to_hill(rk_tod, vk_tod)
+
+        # Position and velocity in PEF to compute the atmospheric drag acceleration.
+        svk_tod = OrbitStateVector(jd_utc, rk_tod, vk_tod)
+        svk_pef = sv_eci_to_ecef(svk_tod, TOD(), PEF(), jd_utc)
+        rk_pef  = svk_pef.r
+        vk_pef  = svk_pef.v
+
+        # Drag acceleration in PEF.
+        adrag_pef = _atmospheric_drag_acceleration(
+            jd_utc,
+            rk_pef,
+            vk_pef,
+            mean_area,
+            mass,
+            C_d;
+            F107 = F107,
+            Ap = Ap
+        )
+
+        # Drag acceleration in TOD.
+        adrag_tod = D_tod_pef * adrag_pef
+
+        # Solar radiation pressure acceleration in TOD.
+        asrp_tod = _solar_radiation_acceleration(rk_tod, rsun_tod, mean_area, mass, C_r)
+
+        # Compute accelerations in Hill frame.
+        adrag_hill = D_hill_tod * adrag_tod
+        asrp_hill  = D_hill_tod * asrp_tod
+
+        # Gauss equations with mean parameters
+        Ak, Bk = _gauss_variational_matrices(ā, ē, ī, ω̄, f̄k, rk, p̄, h̄, η̄, n̄)
+
+        # Temporal weighting.
+        w_t = rk² / h̄
+
+        ∂u_drag = ∂u_drag + w_t * (Ak * adrag_hill + Bk)
+        ∂u_srp  = ∂u_srp  + w_t * (Ak * asrp_hill  + Bk)
+
+        Wsum += w_t
+    end
+
+    # Normalize.
+    if Wsum > 0
+        ∂u_drag = ∂u_drag / Wsum
+        ∂u_srp  = ∂u_srp  / Wsum
+    else
+        ∂u_drag = @SVector zeros(T, 6)
+        ∂u_srp  = @SVector zeros(T, 6)
+    end
+
+    return ∂u_drag, ∂u_srp
+end
+
+"""
+    J₂²_variational_rates(
+        ā::T,
+        ē::T,
+        ī::T,
+        ω̄::T,
+        gm::AbstractGravityModel
+    ) where T<:Number -> SVector{6, T}
+
+Compute averaged Gauss variation rates due to Earth's J₂² mean effects.
+
+This routine calculates the mean (averaged) rates of change of the orbital elements under
+second-order zonal harmonic effects (J2 squared), using the closed-form expressions for the
+long-term (secular and long-period) variations.
+
+# Arguments
+
+- `ā::T`: Mean semi-major axis [m].
+- `ē::T`: Mean eccentricity [-].
+- `ī::T`: Mean inclination [rad].
+- `ω̄::T`: Mean argument of perigee [rad].
+- `gm::AbstractGravityModel`: Gravity model for Earth.
+
+# Returns
+
+- `SVector{6, T}`: Averaged Gauss rates due to J₂² effects.
+"""
+function J₂²_variational_rates(
+    ā::T,
+    ē::T,
+    ī::T,
+    ω̄::T,
+    gm::AbstractGravityModel
+) where T<:Number
+    μ    = GravityModels.gravity_constant(gm)
+    Re   = GravityModels.radius(gm)
+    C₂_₀ = GravityModels.coefficients(gm, 2, 0) |> first
+    J₂   = -C₂_₀ * √5
+
+    # Regularization.
+    ē = max(ē, 1e-6)
+    ī = max(ī, 1e-6)
+
+    # Auxiliary variables.
+    ē²    = ē^2
+    ē⁴    = ē²^2
+    η̄²    = 1 - ē²
+    η̄     = √η̄²
+    p̄     = ā * η̄²
+    n̄     = √(μ / ā^3)
+    R̄e    = Re / p̄
+    R̄e²   = R̄e^2
+    R̄e⁴   = R̄e²^2
+    J₂²   = J₂^2
+    k₁     = n̄ * J₂² * R̄e⁴
+
+    sin_ī, cos_ī   = sincos(ī)
+    sin_ī²         = sin_ī^2
+    sin_ī⁴         = sin_ī²^2
+    sin_2ω̄, cos_2ω̄ = sincos(2ω̄)
+
+    # Mean J₂² rates.
+    ∂a = T(0)
+
+    ∂e = (-3 // 2) * k₁ * sin_ī² * (14 - 15 * sin_ī^2) * ē * η̄² * sin_2ω̄
+
+    ∂i = (+3 // 64) * k₁ * sin(2ī) * (14 - 15 * sin_ī²) * ē² * sin_2ω̄
+
+    ∂Ω = (-3 //  2) * k₁ * cos_ī * (
+        ((9 // 4) + (3 // 2) * η̄) -
+        ((5 // 2) + (9 // 4) * η̄) * sin_ī² +
+        (1 // 4) * (1 + (5 // 4) * sin_ī²) * ē²
+    ) + (-3 // 16) * n̄ * J₂² * R̄e⁴ * cos_ī * (7 - 15sin_ī²) * ē² * cos_2ω̄
+
+    ∂ω = (+3 // 4) * k₁ * (
+        12 - (103 // 4) * sin_ī² + (215 // 16) * sin_ī⁴ + (
+            (7 // 4) - (9 // 8) * sin_ī² - (45 // 32) * sin_ī⁴
+        ) * ē^2 + (3 // 2) * (1 - (3 // 2) * sin_ī²) * (4 - 5 * sin_ī²) * η̄
+    ) + (3 // 64) * k₁ * (
+            -2 * (14 - 15 * sin_ī²) * sin_ī² + (28 - 158 * sin_ī² + 135 * sin_ī⁴) * ē^2
+        ) * cos_2ω̄
+
+    ∂M = (+3 // 2) * n̄ * R̄e² * (1 - (3 // 2) * sin_ī²) * η̄² * (-15 // 8) * k₁ * (
+        (-1 + (5 // 2) * sin_ī² - (13 // 8) * sin_ī⁴) +
+        (1 // 2) * ē² * (-1 + sin_ī² + (5 // 8) * sin_ī⁴)
+    ) + (+3 //  2) * k₁ * (1 - (3 // 2) * sin_ī²)^2 * η̄² +
+        (-9 // 64) * k₁ * sin_ī² * (14 - 15 * sin_ī²) * ē² * η̄ * cos_2ω̄ +
+        (+3 // 32) * k₁ * sin_ī² * (14 - 15 * sin_ī²) * η̄^3 * cos_2ω̄ +
+        (+9 //  8) * k₁ / η̄ * (
+            (3 - (15 // 2) * sin_ī² + (47 // 8) * sin_ī⁴) +
+            ((3 // 2) - 5 * sin_ī² + (117 // 16) * sin_ī⁴) * ē² +
+            (1 // 8) * (1 + 5 * sin_ī² - (101 // 8) * sin_ī⁴) * ē² +
+            (1 // 24) * sin_ī² * (
+                (70 - 123 * sin_ī²) * ē² +
+                2 * (28 - 33 * sin_ī²) * ē⁴
+            ) * cos_2ω̄ +
+            (9 // 128) * ē⁴ * sin_ī⁴ * cos(4ω̄)
+        )
+
+    return @SVector T[∂a, ∂e, ∂i, ∂Ω, ∂ω, ∂M]
+end

--- a/src/SatelliteAnalysis.jl
+++ b/src/SatelliteAnalysis.jl
@@ -20,6 +20,7 @@ using Statistics
 
 include("./beta_angle.jl")
 include("./eclipse_time.jl")
+include("./decay_analysis.jl")
 include("./frozen_orbits.jl")
 include("./ground_repeating_orbits.jl")
 include("./ground_track.jl")

--- a/src/decay_analysis.jl
+++ b/src/decay_analysis.jl
@@ -1,0 +1,11 @@
+## Description #############################################################################
+#
+# This file contains functions for analyzing satellite decay.
+#
+############################################################################################
+
+export decay_analysis
+
+function decay_analysis(::Any)
+    error("Load OrdinaryDiffEq to use `decay_analysis`.")
+end


### PR DESCRIPTION
As we need this analysis to verify the fuel budget, it is interesting to add this functionality for space mission analysis. Previously, this was done using NASA's DAS.

This feature helps perform this analysis natively in Julia, providing a alternative for satellite decay estimation.